### PR TITLE
add no-l3-token-bridge arg

### DIFF
--- a/.github/workflows/run-nitro-test-node.yml
+++ b/.github/workflows/run-nitro-test-node.yml
@@ -30,3 +30,12 @@ jobs:
         with:
           args: --detach
 
+  run-with-simple:
+    name: 'Run in simple mode'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./run-nitro-test-node
+        with:
+          no-simple: false
+

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -5,6 +5,10 @@ inputs:
     required: false
     default: 'false'
     description: 'Whether to skip deploying the token bridge on the test node'
+  no-l3-token-bridge:
+    required: false
+    default: 'false'
+    description: 'Whether to skip deploying the L3 token bridge on the test node'
   args:
     required: false
     default: ''
@@ -31,7 +35,10 @@ runs:
       # See https://stackoverflow.com/a/72203688 for more info
       run: |
         cd nitro-testnode
-        ./test-node.bash --init ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '' }} ${{ inputs.args }} &
+        ./test-node.bash --init ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
+          ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
+          ${{ inputs.no-l3-token-bridge == 'true' && '' || '--l3-token-bridge' }} \
+          ${{ inputs.args }} &
 
     - name: Wait for nitro startup
       shell: bash

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -41,7 +41,7 @@ runs:
         cd nitro-testnode
         ./test-node.bash --init ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
           ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
-          ${{ inputs.no-l3-token-bridge == 'false' && inputs.l3-node == 'true' && '--l3-token-bridge' || '' }} \
+          ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' && '--l3-token-bridge' || '' }} \
           ${{ inputs.args }} &
 
     - name: Wait for nitro startup
@@ -56,4 +56,9 @@ runs:
     - name: Wait for token bridge deployment
       if: ${{ inputs.no-token-bridge != 'true' }}
       shell: bash
-      run: ${{ github.action_path }}/waitForTokenBridge.sh
+      run: ${{ github.action_path }}/waitForTokenBridge.sh l1l2_network.json
+
+    - name: Wait for token bridge deployment
+      if: ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/waitForTokenBridge.sh l2l3_network.json

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -9,13 +9,17 @@ inputs:
     required: false
     default: 'false'
     description: 'Whether to skip deploying the L3 token bridge on the test node'
+  no-simple:
+    required: false
+    default: 'true'
+    description: 'Whether to start the test node in simple mode'
   args:
     required: false
     default: ''
     description: 'Additional args that can be supplied to the test node script'
   nitro-testnode-ref:
     required: false
-    default: 'old-release-v2.1.1'
+    default: 'release'
     description: 'The nitro-testnode branch to use'
   l3-node:
     required: false
@@ -39,7 +43,8 @@ runs:
       # See https://stackoverflow.com/a/72203688 for more info
       run: |
         cd nitro-testnode
-        ./test-node.bash --init ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
+        ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
+          ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
           ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
           ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' && '--l3-token-bridge' || '' }} \
           ${{ inputs.args }} &
@@ -56,7 +61,7 @@ runs:
     - name: Wait for token bridge deployment
       if: ${{ inputs.no-token-bridge != 'true' }}
       shell: bash
-      run: ${{ github.action_path }}/waitForTokenBridge.sh l1l2_network.json
+      run: ${{ github.action_path }}/waitForTokenBridge.sh localNetwork.json
 
     - name: Wait for token bridge deployment
       if: ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' }}

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -41,7 +41,7 @@ runs:
         cd nitro-testnode
         ./test-node.bash --init ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
           ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
-          ${{ inputs.no-l3-token-bridge == 'true' && '' || '--l3-token-bridge' }} \
+          ${{ inputs.no-l3-token-bridge == 'false' && inputs.l3-node == 'true' && '--l3-token-bridge' || '' }} \
           ${{ inputs.args }} &
 
     - name: Wait for nitro startup

--- a/run-nitro-test-node/waitForTokenBridge.sh
+++ b/run-nitro-test-node/waitForTokenBridge.sh
@@ -1,7 +1,7 @@
 # poll the token bridge deployment file until we get a 0 return code
 while true
 do
-  docker-compose -f ./nitro-testnode/docker-compose.yaml run --entrypoint sh tokenbridge -c "cat localNetwork.json"
+  docker-compose -f ./nitro-testnode/docker-compose.yaml run --entrypoint sh tokenbridge -c "cat $1"
   if [ "$?" -eq "0" ]; then
     exit 0
   else


### PR DESCRIPTION
works with https://github.com/OffchainLabs/nitro-testnode/pull/31

- add `no-l3-token-bridge` (default: false)
- add `no-simple` (default: true)
- wait for l3 token bridge deployment if enabled