### PR TITLE
Add var to use custom nitro-contracts branch

### DIFF
--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -29,6 +29,10 @@ inputs:
     required: false
     default: 'main'
     description: 'The nitro-contracts branch to use'
+  token-bridge-branch:
+    required: false
+    default: 'main'
+    description: 'The token-bridge-contracts branch to use'
 runs:
   using: 'composite'
   steps:
@@ -47,7 +51,8 @@ runs:
       # See https://stackoverflow.com/a/72203688 for more info
       run: |
         cd nitro-testnode
-        NITRO_CONTRACTS_BRANCH=${{ inputs.nitro-contracts-branch }} ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
+        NITRO_CONTRACTS_BRANCH=${{ inputs.nitro-contracts-branch }} TOKEN_BRIDGE_BRANCH=${{ inputs.token-bridge-branch }} \
+          ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
           ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
           ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
           ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' && '--l3-token-bridge' || '' }} \

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -25,6 +25,10 @@ inputs:
     required: false
     default: 'false'
     description: 'Whether to start an L3 node in addition to the L2 node'
+  nitro-contracts-branch:
+    required: false
+    default: 'main'
+    description: 'The nitro-contracts branch to use'
 runs:
   using: 'composite'
   steps:
@@ -43,7 +47,7 @@ runs:
       # See https://stackoverflow.com/a/72203688 for more info
       run: |
         cd nitro-testnode
-        ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
+        NITRO_CONTRACTS_BRANCH=${{ inputs.nitro-contracts-branch }} ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
           ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
           ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
           ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' && '--l3-token-bridge' || '' }} \


### PR DESCRIPTION
Add option to specify custom nitro-contracts and token-bridge-contracts versions to use with the testnode.

Accompanying https://github.com/OffchainLabs/nitro-testnode/pull/47