### PR TITLE
Remove contract versions defaults

### DIFF
--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -1,47 +1,45 @@
 name: Run Nitro Test Node
-description: 'Checks out the Nitro repository and runs the local test node setup'
+description: "Checks out the Nitro repository and runs the local test node setup"
 inputs:
   no-token-bridge:
     required: false
-    default: 'false'
-    description: 'Whether to skip deploying the token bridge on the test node'
+    default: "false"
+    description: "Whether to skip deploying the token bridge on the test node"
   no-l3-token-bridge:
     required: false
-    default: 'false'
-    description: 'Whether to skip deploying the L3 token bridge on the test node'
+    default: "false"
+    description: "Whether to skip deploying the L3 token bridge on the test node"
   no-simple:
     required: false
-    default: 'true'
-    description: 'Whether to start the test node in simple mode'
+    default: "true"
+    description: "Whether to start the test node in simple mode"
   args:
     required: false
-    default: ''
-    description: 'Additional args that can be supplied to the test node script'
+    default: ""
+    description: "Additional args that can be supplied to the test node script"
   nitro-testnode-ref:
     required: false
-    default: 'release'
-    description: 'The nitro-testnode branch to use'
+    default: "release"
+    description: "The nitro-testnode branch to use"
   l3-node:
     required: false
-    default: 'false'
-    description: 'Whether to start an L3 node in addition to the L2 node'
+    default: "false"
+    description: "Whether to start an L3 node in addition to the L2 node"
   nitro-contracts-branch:
     required: false
-    default: 'main'
-    description: 'The nitro-contracts branch to use'
+    description: "The nitro-contracts branch/tag/commit to use"
   token-bridge-branch:
     required: false
-    default: 'main'
-    description: 'The token-bridge-contracts branch to use'
+    description: "The token-bridge-contracts branch/tag/commit to use"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         repository: OffchainLabs/nitro-testnode
         submodules: true
-        path: 'nitro-testnode'
+        path: "nitro-testnode"
         ref: ${{ inputs.nitro-testnode-ref }}
 
     - name: Start background nitro-testnode test-node.bash
@@ -51,8 +49,16 @@ runs:
       # See https://stackoverflow.com/a/72203688 for more info
       run: |
         cd nitro-testnode
-        NITRO_CONTRACTS_BRANCH=${{ inputs.nitro-contracts-branch }} TOKEN_BRIDGE_BRANCH=${{ inputs.token-bridge-branch }} \
-          ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
+
+        if [ -n "${{ inputs.nitro-contracts-branch }}" ]; then
+          export NITRO_CONTRACTS_BRANCH="${{ inputs.nitro-contracts-branch }}"
+        fi
+
+        if [ -n "${{ inputs.token-bridge-branch }}" ]; then
+          export TOKEN_BRIDGE_BRANCH="${{ inputs.token-bridge-branch }}"
+        fi
+
+        ./test-node.bash --init ${{ inputs.no-simple == 'true' && '--no-simple' || '' }} \
           ${{ inputs.l3-node == 'true' && '--l3node' || '' }} \
           ${{ inputs.no-token-bridge == 'true' && '--no-tokenbridge' || '--tokenbridge' }} \
           ${{ inputs.l3-node == 'true' && inputs.no-l3-token-bridge != 'true' && '--l3-token-bridge' || '' }} \

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -1,45 +1,45 @@
 name: Run Nitro Test Node
-description: "Checks out the Nitro repository and runs the local test node setup"
+description: 'Checks out the Nitro repository and runs the local test node setup'
 inputs:
   no-token-bridge:
     required: false
-    default: "false"
-    description: "Whether to skip deploying the token bridge on the test node"
+    default: 'false'
+    description: 'Whether to skip deploying the token bridge on the test node'
   no-l3-token-bridge:
     required: false
-    default: "false"
-    description: "Whether to skip deploying the L3 token bridge on the test node"
+    default: 'false'
+    description: 'Whether to skip deploying the L3 token bridge on the test node'
   no-simple:
     required: false
-    default: "true"
-    description: "Whether to start the test node in simple mode"
+    default: 'true'
+    description: 'Whether to start the test node in simple mode'
   args:
     required: false
-    default: ""
-    description: "Additional args that can be supplied to the test node script"
+    default: ''
+    description: 'Additional args that can be supplied to the test node script'
   nitro-testnode-ref:
     required: false
-    default: "release"
-    description: "The nitro-testnode branch to use"
+    default: 'release'
+    description: 'The nitro-testnode branch to use'
   l3-node:
     required: false
-    default: "false"
-    description: "Whether to start an L3 node in addition to the L2 node"
+    default: 'false'
+    description: 'Whether to start an L3 node in addition to the L2 node'
   nitro-contracts-branch:
     required: false
-    description: "The nitro-contracts branch/tag/commit to use"
+    description: 'The nitro-contracts branch to use'
   token-bridge-branch:
     required: false
-    description: "The token-bridge-contracts branch/tag/commit to use"
+    description: 'The token-bridge-contracts branch to use'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         repository: OffchainLabs/nitro-testnode
         submodules: true
-        path: "nitro-testnode"
+        path: 'nitro-testnode'
         ref: ${{ inputs.nitro-testnode-ref }}
 
     - name: Start background nitro-testnode test-node.bash
@@ -53,7 +53,6 @@ runs:
         if [ -n "${{ inputs.nitro-contracts-branch }}" ]; then
           export NITRO_CONTRACTS_BRANCH="${{ inputs.nitro-contracts-branch }}"
         fi
-
         if [ -n "${{ inputs.token-bridge-branch }}" ]; then
           export TOKEN_BRIDGE_BRANCH="${{ inputs.token-bridge-branch }}"
         fi


### PR DESCRIPTION
Testnode script `test-node.bash` now sets default versions for nitro-contracts and token-bridge (PR https://github.com/OffchainLabs/nitro-testnode/pull/52). 
This action can optionally override those, if `nitro-contracts-branch` or `token-bridge-branch` inputs are provided respective env vars will be exported and used in building the testnode.