### PR TITLE
chore: update checkout action from v3 to v4

### DIFF
--- a/.github/workflows/run-nitro-test-node.yml
+++ b/.github/workflows/run-nitro-test-node.yml
@@ -6,35 +6,35 @@ on:
 
 jobs:
   run-with-defaults:
-    name: 'Run with defaults'
+    name: "Run with defaults"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./run-nitro-test-node
 
   run-with-token-bridge:
-    name: 'Run without token bridge deployment'
+    name: "Run without token bridge deployment"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./run-nitro-test-node
         with:
           no-token-bridge: true
 
   run-with-args:
-    name: 'Run with args'
+    name: "Run with args"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./run-nitro-test-node
         with:
           args: --detach
 
   run-with-simple:
-    name: 'Run in simple mode'
+    name: "Run in simple mode"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./run-nitro-test-node
         with:
           no-simple: false

--- a/node-modules/install/README.md
+++ b/node-modules/install/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main

--- a/node-modules/restore/README.md
+++ b/node-modules/restore/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore cache
         uses: OffchainLabs/actions/node-modules/restore@main

--- a/run-nitro-test-node/action.yml
+++ b/run-nitro-test-node/action.yml
@@ -1,45 +1,45 @@
 name: Run Nitro Test Node
-description: 'Checks out the Nitro repository and runs the local test node setup'
+description: "Checks out the Nitro repository and runs the local test node setup"
 inputs:
   no-token-bridge:
     required: false
-    default: 'false'
-    description: 'Whether to skip deploying the token bridge on the test node'
+    default: "false"
+    description: "Whether to skip deploying the token bridge on the test node"
   no-l3-token-bridge:
     required: false
-    default: 'false'
-    description: 'Whether to skip deploying the L3 token bridge on the test node'
+    default: "false"
+    description: "Whether to skip deploying the L3 token bridge on the test node"
   no-simple:
     required: false
-    default: 'true'
-    description: 'Whether to start the test node in simple mode'
+    default: "true"
+    description: "Whether to start the test node in simple mode"
   args:
     required: false
-    default: ''
-    description: 'Additional args that can be supplied to the test node script'
+    default: ""
+    description: "Additional args that can be supplied to the test node script"
   nitro-testnode-ref:
     required: false
-    default: 'release'
-    description: 'The nitro-testnode branch to use'
+    default: "release"
+    description: "The nitro-testnode branch to use"
   l3-node:
     required: false
-    default: 'false'
-    description: 'Whether to start an L3 node in addition to the L2 node'
+    default: "false"
+    description: "Whether to start an L3 node in addition to the L2 node"
   nitro-contracts-branch:
     required: false
-    description: 'The nitro-contracts branch to use'
+    description: "The nitro-contracts branch to use"
   token-bridge-branch:
     required: false
-    description: 'The token-bridge-contracts branch to use'
+    description: "The token-bridge-contracts branch to use"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: OffchainLabs/nitro-testnode
         submodules: true
-        path: 'nitro-testnode'
+        path: "nitro-testnode"
         ref: ${{ inputs.nitro-testnode-ref }}
 
     - name: Start background nitro-testnode test-node.bash


### PR DESCRIPTION
NodeJs 16 is deprecated. Github actions were throwing quite a few warnings to upgrade to Node v20. This fixes it.

Checkout/actionsv4 uses v20 by default : https://github.com/actions/checkout/blob/v4/CHANGELOG.md#v400