### PR TITLE
Use native restore

### DIFF
--- a/node-modules/restore/action.yml
+++ b/node-modules/restore/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Restore "node_modules" from cache
-      uses: martijnhols/actions-cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: "**/node_modules"
         key: ${{ inputs.cache-key }}


### PR DESCRIPTION
I noticed we moved from martijnhols/restore to actions/restore for install action here: https://github.com/OffchainLabs/actions/commit/a20a76172ce524832ac897bef2fa10a62ed81c29

Are we ok to use that in the restore job too? Nitro contracts seems to be failing here if I dont do this for some reason - I guess the two types of restore (we use a different in install to the one we use in restore) are incompatible.